### PR TITLE
If session has expired clear out session id/encoding to allow logging in

### DIFF
--- a/lib/silverpop/engage.rb
+++ b/lib/silverpop/engage.rb
@@ -66,6 +66,8 @@ module Silverpop
       if e.message == 'Session has expired or is invalid'
         @session_id = nil
         @session_encoding = nil
+      else
+        raise e
       end
     end
 

--- a/lib/silverpop/engage.rb
+++ b/lib/silverpop/engage.rb
@@ -61,6 +61,12 @@ module Silverpop
         @session_encoding = nil
       end
       success?
+
+    rescue => e
+      if e.message == 'Session has expired or is invalid'
+        @session_id = nil
+        @session_encoding = nil
+      end
     end
 
     def logged_in?


### PR DESCRIPTION
The logout query fails if the session has expired. In this case that this happens, we need to clear out the session information to enable login later.